### PR TITLE
Add `group: edge` to fix GH Release deployment issue on Power

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: go
 dist: focal # default (xenial) does not work
 arch: ppc64le
 os: linux
+group: edge
 
 go:
 - 1.18
@@ -14,24 +15,14 @@ before_script:
 script:
 - hack/build_providers.sh /tmp/archive.zip
 
-before_deploy:
-  - cd /tmp
-  - git clone https://github.com/travis-ci/dpl
-  - cd dpl
-  - git checkout v1.10.16
-  - sed -i 's/< 0.16.0/~> 0.17.3/g' dpl-releases.gemspec
-  - sed -i 's/4.6.2/4.15.0/g' dpl-releases.gemspec
-  - gem build dpl-releases.gemspec && cp *.gem "$TRAVIS_BUILD_DIR"
-  - cd $TRAVIS_BUILD_DIR
-
 deploy:
   provider: releases
   api_key: ${GITHUB_OAUTH_TOKEN}
   file: /tmp/archive.zip
   skip_cleanup: true
-  edge: local
   on:
     tags: true
+  edge: true
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,22 @@ before_script:
 script:
 - hack/build_providers.sh /tmp/archive.zip
 
+before_deploy:
+  - cd /tmp
+  - git clone https://github.com/travis-ci/dpl
+  - cd dpl
+  - git checkout v1.10.16
+  - sed -i 's/< 0.16.0/~> 0.17.3/g' dpl-releases.gemspec
+  - sed -i 's/4.6.2/4.15.0/g' dpl-releases.gemspec
+  - gem build dpl-releases.gemspec && cp *.gem "$TRAVIS_BUILD_DIR"
+  - cd $TRAVIS_BUILD_DIR
+
 deploy:
   provider: releases
   api_key: ${GITHUB_OAUTH_TOKEN}
   file: /tmp/archive.zip
   skip_cleanup: true
+  edge: local
   on:
     tags: true
 


### PR DESCRIPTION
The default version of `faraday` (0.15.4) and `octokit` (4.6.2) are incompatible with default ruby version (3.1.2) used by the dpl gem to deploy build artifacts to GitHub Releases.

Proposed is the temporary hack to unblock any further releases until new images are updated in the build environment.
