### PR TITLE
Update IBM provider version to 1.54.0

### DIFF
--- a/hack/build_providers.sh
+++ b/hack/build_providers.sh
@@ -43,7 +43,7 @@ clone_build
 
 PROVIDER_NAME=ibm
 PROVIDER_ORG=IBM-Cloud
-VERSION=1.52.0
+VERSION=1.54.0
 clone_build
 
 cd $PROVIDERS_PATH


### PR DESCRIPTION
For using the fix for LB listener timeout issue.